### PR TITLE
Fix headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 - [License](#license)
 
 
-#about
+# About
 PL/SQL packages enabling Google, Linkedin and Facebook login for apex. Apex-oauth does not rely on any tables. There is one table (S4SA_SETTINGS) that contains some settings you must review and change to reflect your specific situation.
 
 In my presentation at kscope 2015 I promised to release the oauth packages that will enable you to use Google, Facebook and Linked-in authentication in your own applications. I finally got around publishing them.
@@ -25,10 +25,10 @@ To enable your apex-application to use apex_oauth you need to register yourself 
 
 There you will be able to create an application. The Provider (Google, Facebook etc.) will then provide you some codes which you must put in the s4a_settings table.
 
-#download
+# Download
 It is recommended that you download a certified release (from the [releases](https://github.com/smart4solutions/apex_oauth/releases) folder). The files in the current repository are for the next release and should be considered unstable.
 
-#installation
+# Installation
 The product consists of a number of database-objects:
 - packages
 - tables
@@ -37,7 +37,7 @@ The product consists of a number of database-objects:
 
 Please follow directions below to complete your installation.
 
-##install into an existing application
+## Install into an existing application
 1. as sys: login into your database and execute the "`grant_as_sysdba.sql`" script. It will grant execute on the sys_http package to your parsing schema
 2. in apex, login into your workspace
 3. within the SQL Workshop:
@@ -54,16 +54,16 @@ Please follow directions below to complete your installation.
   - remove the username and password items
   - rename the login-button so it reflects the value of the `S4SA_GGL_LOGIN_REQUEST` record in your `S4SA_SETTINGS` table (default `GGL_LOGIN`)
 
-##install into a new application
+## Install into a new application
 1. Create your application
 2. follow the steps in "install into an existing application"
 3. continue developing your application
 
-#httpd configuration
+# httpd configuration
 It is highly advisable to use a everse proxy as described in my [blog](http://richardmartens.blogspot.nl/2015/07/making-https-webservice-requests-from.html title="blogspot").
 I have included the settings as I use them in my web-server setup. This prevents you from having to create an Oracle wallet. It also alows you to use Linked-in as the oauth provider. Since Linked-in uses a specific algorithm that is not supported below Oracle 11.2.0.3.
 
-#the S4SA_SETTINGS table
+# The S4SA_SETTINGS table
 This table is the only table in use. It contains the settings for the API calls being made:
 
 Code | Description
@@ -98,5 +98,5 @@ Code | Description
 `S4SA_FCB_SCOPE` | Facebook scopes
 `S4SA_FCB_FORCE_APPROVAL` | Facebook force approval y/n
 
-#license
+# License
 This project is uses the [MIT license](LICENSE).


### PR DESCRIPTION
The markdown parser on GitHub requires a space after the `#` in order for the headings to render properly.

Just to make the documentation a bit more readable.